### PR TITLE
docs: update v-text directive details for clarity

* docs: update v-text directive details for clarity

Clarified usage of v-text directive regarding textContent updates.

* Update explanation

* Fix formatting in v-text documentation example 

### DIFF
--- a/src/api/built-in-directives.md
+++ b/src/api/built-in-directives.md
@@ -8,7 +8,7 @@ Update the element's text content.
 
 - **Details**
 
-  `v-text` works by setting the element's [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) property, so it will overwrite any existing content inside the element. If you need to update the part of `textContent`, you should use [mustache interpolations](/guide/essentials/template-syntax#text-interpolation) instead.
+  `v-text` works by setting the element's [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) property, so it will overwrite any existing content inside the element. If you need to update only part of the `textContent`, you should use [mustache interpolations](/guide/essentials/template-syntax#text-interpolation) instead (ie. <span v-pre>`<span>Keep this but update a {{dynamicPortion}}</span>`</span>).
 
 - **Example**
 


### PR DESCRIPTION
resolves #null
Cherry picked from https://github.com/vuejs/docs/commit/f828958be70ec45495ff16ed4aad0bc55952c4bf