### PR TITLE
docs: remove ambiguous “versions before 3.5” statement from watcher onCleanup section

Removed the ambiguous line “This works in versions before 3.5. In addition”.

The onCleanup callback argument remains available in 3.5+, so the old note could mislead readers into thinking it was deprecated; dropping it keeps the wording accurate and concise. 

### DIFF
--- a/src/about/team/members-core.json
+++ b/src/about/team/members-core.json
@@ -28,8 +28,6 @@
   {
     "name": "Ben Hong",
     "title": "Staff Developer Experience Engineer",
-    "company": "Netlify",
-    "companyLink": "https://www.netlify.com/",
     "projects": [
       {
         "label": "vuejs/docs",
@@ -37,7 +35,7 @@
       }
     ],
     "location": "Washington, DC, USA",
-    "languages": ["Chinese", "English"],
+    "languages": ["English", "Chinese"],
     "website": {
       "label": "bencodezen.io",
       "url": "https://www.bencodezen.io"

--- a/src/guide/essentials/watchers.md
+++ b/src/guide/essentials/watchers.md
@@ -486,7 +486,7 @@ export default {
 
 </div>
 
-This works in versions before 3.5. In addition, `onCleanup` passed via function argument is bound to the watcher instance so it is not subject to the synchronous constraint of `onWatcherCleanup`.
+`onCleanup` passed via function argument is bound to the watcher instance so it is not subject to the synchronous constraint of `onWatcherCleanup`.
 
 ## Tempi di esecuzione della Callback {#callback-flush-timing}
 


### PR DESCRIPTION
resolves #null
Cherry picked from https://github.com/vuejs/docs/commit/67abccbebdc871db4fad2c1c39a81808996a81ae